### PR TITLE
fix(os): switch base image to bazzite-nvidia-open

### DIFF
--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -1,6 +1,6 @@
 name: naia-os
 description: Naia - Personal AI OS with virtual avatar
-base-image: ghcr.io/ublue-os/bazzite
+base-image: ghcr.io/ublue-os/bazzite-nvidia-open
 image-version: latest
 
 modules:


### PR DESCRIPTION
## Summary
- Base image changed from `ghcr.io/ublue-os/bazzite` to `ghcr.io/ublue-os/bazzite-nvidia-open`
- Naia OS was shipping without NVIDIA drivers — RTX GPUs (3090 x2) not functional
- `bazzite-nvidia-open` includes open-source NVIDIA kernel modules (nvidia-open)

## Test plan
- [ ] CI build passes with new base image
- [ ] Smoke test: `nvidia-smi` works on installed system
- [ ] Verify `lsmod | grep nvidia` shows loaded modules after reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)